### PR TITLE
Proxied request path made configurable

### DIFF
--- a/src/AspNetCore.SpaYarp/AspNetCore.SpaYarp.csproj
+++ b/src/AspNetCore.SpaYarp/AspNetCore.SpaYarp.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.12.21451.3" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNetCore.SpaYarp/Extensions/IEndpointRouteBuilderExtensions.cs
+++ b/src/AspNetCore.SpaYarp/Extensions/IEndpointRouteBuilderExtensions.cs
@@ -38,9 +38,9 @@ public static class IEndpointRouteBuilderExtensions
         });
 
         var transformer = new CustomTransformer();
-        var requestOptions = new ForwarderRequestConfig { Timeout = TimeSpan.FromSeconds(100) };
+        var requestOptions = new ForwarderRequestConfig { ActivityTimeout = TimeSpan.FromSeconds(100) };
 
-        endpoints.Map("/{**catch-all}", async httpContext =>
+        endpoints.Map(String.Format("{0}/{{**catch-all}}", spaOptions.PublicPath), async httpContext =>
         {
             var error = await forwarder.SendAsync(httpContext, spaOptions.ClientUrl, httpClient, requestOptions, transformer);
             // Check if the proxy operation was successful

--- a/src/AspNetCore.SpaYarp/SpaDevelopmentServerOptions.cs
+++ b/src/AspNetCore.SpaYarp/SpaDevelopmentServerOptions.cs
@@ -12,4 +12,6 @@ public class SpaDevelopmentServerOptions
     public TimeSpan MaxTimeout => TimeSpan.FromSeconds(MaxTimeoutInSeconds);
 
     public string WorkingDirectory { get; set; } = "";
+
+    public string PublicPath { get; set; } = "";
 }

--- a/src/AspNetCore.SpaYarp/build/AspNetCore.SpaYarp.targets
+++ b/src/AspNetCore.SpaYarp/build/AspNetCore.SpaYarp.targets
@@ -12,7 +12,8 @@
       <_SpaProxyServerLaunchConfigLines Include="    &quot;ClientUrl&quot;: &quot;$(SpaClientUrl)&quot;," />
       <_SpaProxyServerLaunchConfigLines Include="    &quot;LaunchCommand&quot;: &quot;$(SpaLaunchCommand)&quot;," />
       <_SpaProxyServerLaunchConfigLines Include="    &quot;WorkingDirectory&quot;: &quot;$(_SpaRootFullPath)&quot;," />
-      <_SpaProxyServerLaunchConfigLines Include="    &quot;MaxTimeoutInSeconds&quot;: &quot;$(SpaProxyTimeoutInSeconds)&quot;" />
+      <_SpaProxyServerLaunchConfigLines Include="    &quot;MaxTimeoutInSeconds&quot;: &quot;$(SpaProxyTimeoutInSeconds)&quot;," />
+      <_SpaProxyServerLaunchConfigLines Include="    &quot;PublicPath&quot;: &quot;$(SpaPublicPath)&quot;" />
       <_SpaProxyServerLaunchConfigLines Include="  }" />
       <_SpaProxyServerLaunchConfigLines Include="}" />
     </ItemGroup>


### PR DESCRIPTION
PublicPath option is added to SpaDevelopmentServerOptions in order to proxy (forward to spa dev server) only specific subpath instead of all paths from the root. It corresponds to the 'publicPath' option of Webpack Dev Server.
There is also a minor change to support the updated Yarp.ReverseProxy 1.0.0 release.