### PR TITLE
Implements dark theme launch page

### DIFF
--- a/src/AspNetCore.SpaYarp/SpaProxyMiddleware.cs
+++ b/src/AspNetCore.SpaYarp/SpaProxyMiddleware.cs
@@ -71,6 +71,14 @@ public class SpaProxyMiddleware
   <title>SPA client launch page</title>
 </head>
 <body>
+  <style>
+    @media (prefers-color-scheme: dark) {{
+      :root {{
+        background: black;
+        color: gray;
+      }}
+    }}
+  </style>
   <h1>Launching the SPA client...</h1>
   <p>This page will automatically refresh when the SPA client is ready.</p>
 </body>


### PR DESCRIPTION
Fixes the 'blinding white flash' for dark theme users by adding dark theme background and muted text in the "Launching the SPA client" page.
