### PR TITLE
Upgrade Yarp.ReverseProxy to 2.0.1

### DIFF
--- a/src/AspNetCore.SpaYarp/AspNetCore.SpaYarp.csproj
+++ b/src/AspNetCore.SpaYarp/AspNetCore.SpaYarp.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Yarp.ReverseProxy" Version="2.0.0" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Yarp.ReverseProxy 2.0.0 has a Denial of Service Vulnerability. This vulnerability is fixed in v2.0.1.
See here: https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-33141