### PR TITLE
Replace the policy name attribute in MapSpaYarp with IEndpointConventionBuilder

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -185,6 +185,28 @@ app.MapSpaYarp("two", "https://localhost:44479");
 
 ```
 
+### Configure route conventions
+
+MapSpaYarp returns the `IEndpointConventionBuilder`, which allows to add authorization policies and other route conventions.
+
+Here is an example which adds required authorization:
+
+```cs
+app.UseSpaYarpMiddleware();
+app.MapSpaYarp().RequireAuthorization();
+//app.MapSpaYarp().RequireAuthorization("MySpaYarpPolicy");
+
+```
+
+Here is an example which allows anonymous access (e.g. if authorization is required by default for all Endpoints):
+
+```cs
+app.UseSpaYarpMiddleware();
+app.MapSpaYarp().AllowAnonymousAccess();
+
+```
+
+
 ## Migrate from SpaProxy
 
 This guide assumes that you are using the default ASP.NET Core with Angular Template (but should work the same for other frameworks too).  

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.200",
+    "version": "7.0",
     "rollForward": "latestFeature"
   }
 }

--- a/samples/AspNetMultipleSpaYarp/Program.cs
+++ b/samples/AspNetMultipleSpaYarp/Program.cs
@@ -1,3 +1,5 @@
+using AspNetCore.SpaYarp.Extensions;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.

--- a/samples/Net6Startup/Startup.cs
+++ b/samples/Net6Startup/Startup.cs
@@ -1,3 +1,5 @@
+using AspNetCore.SpaYarp.Extensions;
+
 public class Startup
 {
     public Startup(IConfiguration configuration)

--- a/src/AspNetCore.SpaYarp/AspNetCore.SpaYarp.csproj
+++ b/src/AspNetCore.SpaYarp/AspNetCore.SpaYarp.csproj
@@ -12,7 +12,7 @@
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<Authors>Bernd Hirschmann</Authors>
 		<Company>Guid.New GmbH</Company>
-		<Version>2.0.1</Version>
+		<Version>2.0.2</Version>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageReadmeFile>Readme.md</PackageReadmeFile>
 	</PropertyGroup>

--- a/src/AspNetCore.SpaYarp/Extensions/WebApplicationExtensions.cs
+++ b/src/AspNetCore.SpaYarp/Extensions/WebApplicationExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.AspNetCore.Builder;
+﻿using AspNetCore.SpaYarp.Extensions;
+
+namespace Microsoft.AspNetCore.Builder;
 
 public static class WebApplicationExtensions
 {


### PR DESCRIPTION
Return the IEndpointConventionBuilder instead of passing a policyName. 
This allows more flexibility in the configuration of the endpoint such as AllowAnonymous or RequireAuthorization.

Also added a section in the Readme.md and fixed some small issues which prevented me from building (e.g. the version in global.json). 

Increased the version from 2.0.1 to 2.0.2.